### PR TITLE
chore: support 0.36.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,8 @@
 name: http-params-serializable
 version: 0.4.1
+crystal: ">= 0.35"
 
 authors:
   - Vlad Faust <mail@vladfaust.com>
-
-crystal: ~> 0.35
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,9 @@
 name: http-params-serializable
-version: 0.4.0
+version: 0.4.1
 
 authors:
   - Vlad Faust <mail@vladfaust.com>
 
-crystal: 0.30.1
+crystal: ~> 0.35
 
 license: MIT

--- a/src/http-params-serializable.cr
+++ b/src/http-params-serializable.cr
@@ -89,9 +89,9 @@ module HTTP::Params::Serializable
   # Instance variables are by default seralized under camelCased keys,
   # unless explicitly specified with `@[HTTP::Param(key: "mykey")`.
   def to_query : String
-    builder = HTTP::Params::Builder.new
-    to_http_param(builder)
-    builder.to_s
+    HTTP::Params.build do |builder|
+      to_http_param(builder)
+    end.to_s
   end
 
   macro included

--- a/src/http-params-serializable/annotations.cr
+++ b/src/http-params-serializable/annotations.cr
@@ -1,3 +1,6 @@
+require "uri"
+require "http"
+
 module HTTP
   # An HTTP parameter annotation.
   #

--- a/src/http-params-serializable/ext/char.cr
+++ b/src/http-params-serializable/ext/char.cr
@@ -15,6 +15,6 @@ struct Char
   def self.from_http_param(value : String)
     chars = value.chars
     raise TypeCastError.new if chars.size != 1
-    return chars.first
+    chars.first
   end
 end

--- a/src/http-params-serializable/ext/string.cr
+++ b/src/http-params-serializable/ext/string.cr
@@ -13,6 +13,6 @@ class String
 
   # Parse `String` from an HTTP param (basically return itself).
   def self.from_http_param(value : String)
-    return value
+    value
   end
 end

--- a/src/http-params-serializable/ext/time/epoch_converter.cr
+++ b/src/http-params-serializable/ext/time/epoch_converter.cr
@@ -15,7 +15,7 @@ struct Time
 
     # Parse `Time` from an HTTP param as unix timestamp.
     def self.from_http_param(value : String) : Time
-      return Time.unix(value.to_i64)
+      Time.unix(value.to_i64)
     rescue ArgumentError
       raise TypeCastError.new
     end

--- a/src/http-params-serializable/ext/uri.cr
+++ b/src/http-params-serializable/ext/uri.cr
@@ -15,6 +15,6 @@ class URI
 
   # Parse `URI` from an HTTP param.
   def self.from_http_param(value : String)
-    return URI.parse(value)
+    URI.parse(value)
   end
 end


### PR DESCRIPTION
Removes use of deprecated use of `HTTP::Params::Builder`, fixes ameba lints, and bumps minor version.